### PR TITLE
view all posts functionality achieved

### DIFF
--- a/TabloidFullStack/SQLQuery1.sql
+++ b/TabloidFullStack/SQLQuery1.sql
@@ -1,0 +1,118 @@
+﻿USE [master]
+
+IF db_id('Tabloid') IS NULl
+  CREATE DATABASE [Tabloid]
+GO
+
+USE [Tabloid]
+GO
+
+
+DROP TABLE IF EXISTS [PostReaction];
+DROP TABLE IF EXISTS [Reaction];
+DROP TABLE IF EXISTS [PostTag];
+DROP TABLE IF EXISTS [Tag];
+DROP TABLE IF EXISTS [Comment];
+DROP TABLE IF EXISTS [Post];
+DROP TABLE IF EXISTS [Category];
+DROP TABLE IF EXISTS [Subscription];
+DROP TABLE IF EXISTS [UserProfile];
+DROP TABLE IF EXISTS [UserType];
+GO
+
+
+CREATE TABLE [UserType] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [Name] nvarchar(20) NOT NULL
+)
+
+CREATE TABLE [UserProfile] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [DisplayName] nvarchar(50) NOT NULL,
+  [FirstName] nvarchar(50) NOT NULL,
+  [LastName] nvarchar(50) NOT NULL,
+  [Email] nvarchar(555) NOT NULL,
+  [CreateDateTime] datetime NOT NULL,
+  [ImageLocation] nvarchar(255),
+  [UserTypeId] integer NOT NULL,
+
+  CONSTRAINT [FK_User_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id]),
+)
+
+CREATE TABLE [Subscription] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [SubscriberUserProfileId] integer NOT NULL,
+  [ProviderUserProfileId] integer NOT NULL,
+  [BeginDateTime] datetime NOT NULL,
+  [EndDateTime] datetime,
+
+  CONSTRAINT [FK_Subscription_UserProfile_Subscriber] FOREIGN KEY ([SubscriberUserProfileId])
+	REFERENCES [UserProfile] ([Id]),
+
+  CONSTRAINT [FK_Subscription_UserProfile_Provider] FOREIGN KEY ([ProviderUserProfileId])
+	REFERENCES [UserProfile] ([Id])
+)
+
+CREATE TABLE [Category] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [Name] nvarchar(50) NOT NULL
+)
+
+CREATE TABLE [Post] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [Title] nvarchar(255) NOT NULL,
+  [Content] text NOT NULL,
+  [ImageLocation] nvarchar(255),
+  [CreateDateTime] datetime NOT NULL,
+  [PublishDateTime] datetime,
+  [IsApproved] bit NOT NULL,
+  [CategoryId] integer NOT NULL,
+  [UserProfileId] integer NOT NULL,
+
+  CONSTRAINT [FK_Post_Category] FOREIGN KEY ([CategoryId]) REFERENCES [Category] ([Id]),
+  CONSTRAINT [FK_Post_UserProfile] FOREIGN KEY ([UserProfileId]) REFERENCES [UserProfile] ([Id])
+)
+
+CREATE TABLE [Comment] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [PostId] integer NOT NULL,
+  [UserProfileId] integer NOT NULL,
+  [Subject] nvarchar(255) NOT NULL,
+  [Content] text NOT NULL,
+  [CreateDateTime] datetime NOT NULL,
+
+  CONSTRAINT [FK_Comment_Post] FOREIGN KEY ([PostId]) REFERENCES [Post] ([Id]),
+  CONSTRAINT [FK_Comment_UserProfile] FOREIGN KEY ([UserProfileId]) REFERENCES [UserProfile] ([Id])
+)
+
+CREATE TABLE [Tag] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [Name] nvarchar(50) NOT NULL
+)
+
+CREATE TABLE [PostTag] (
+  [id] integer PRIMARY KEY IDENTITY,
+  [PostId] integer NOT NULL,
+  [TagId] integer NOT NULL,
+
+  CONSTRAINT [FK_PostTag_Post] FOREIGN KEY ([PostId]) REFERENCES [Post] ([Id]),
+  CONSTRAINT [FK_PostTag_Tag] FOREIGN KEY ([TagId]) REFERENCES [Tag] ([Id])
+)
+
+CREATE TABLE [Reaction] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [Name] nvarchar(50) NOT NULL,
+  [ImageLocation] nvarchar(255) NOT NULL
+)
+
+CREATE TABLE [PostReaction] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [PostId] integer NOT NULL,
+  [ReactionId] integer NOT NULL,
+  [UserProfileId] integer NOT NULL,
+
+  CONSTRAINT [FK_PostReaction_Post] FOREIGN KEY ([PostId]) REFERENCES [Post] ([Id]),
+  CONSTRAINT [FK_PostReaction_Reaction] FOREIGN KEY ([ReactionId]) REFERENCES [Reaction] ([Id]),
+  CONSTRAINT [FK_PostReaction_UserProfile] FOREIGN KEY ([UserProfileId]) REFERENCES [UserProfile] ([Id])
+)
+GO

--- a/TabloidFullStack/SQLQuery2.sql
+++ b/TabloidFullStack/SQLQuery2.sql
@@ -1,0 +1,339 @@
+﻿USE [Tabloid];
+GO
+
+set identity_insert [UserType] on
+insert into [UserType] ([ID], [Name]) VALUES (1, 'Admin'), (2, 'Author');
+set identity_insert [UserType] off
+
+set identity_insert [Category] on
+insert into [Category] ([Id], [Name])
+values (1, 'Technology'), (2, 'Politics'), (3, 'Science'), (4, 'Cooking'), (5, 'Music'),
+	   (6, 'Cthulhu Sightings'), (7, 'History'), (8, 'Home and Garden'), (9, 'Entertainment')
+set identity_insert [Category] off
+
+set identity_insert [Tag] on
+insert into [Tag] ([Id], [Name])
+values (1, 'C#'), (2, 'JavaScript'), (3, 'Funny'), (4, 'Scary');
+set identity_insert [Tag] off
+
+set identity_insert [UserProfile] on
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (1, 'Foo', 'Foo', 'Barington', 'foo@bar.com', '2020-04-23', 'https://robohash.org/numquamutut.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (2, 'rsandwith0', 'Reina', 'Sandwith', 'rsandwith0@google.com.brx', '2020-04-23', 'https://robohash.org/numquamutut.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (3, 'rdo1', 'Red', 'Do', 'rdo1@timesonline.co.ukx', '2020-04-20', 'https://robohash.org/nisiautemet.png?size=150x150&set=set1', 2);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (4, 'aotton2', 'Arnold', 'Otton', 'aotton2@ow.lyx', '2020-01-13', 'https://robohash.org/molestiaemagnamet.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (5, 'agrzeskowski3', 'Aharon', 'Grzeskowski', 'agrzeskowski3@fc2.comx', '2020-04-12', 'https://robohash.org/doloremfugiatrerum.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (6, 'ryakushkev4', 'Rosana', 'Yakushkev', 'ryakushkev4@weibo.comx', '2019-08-16', 'https://robohash.org/deseruntutipsum.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (7, 'tfigiovanni5', 'Tobi', 'Figiovanni', 'tfigiovanni5@baidu.comx', '2019-10-17', 'https://robohash.org/quiundedignissimos.png?size=150x150&set=set1', 2);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (8, 'gteanby6', 'Giuseppe', 'Teanby', 'gteanby6@craigslist.orgx', '2019-08-29', 'https://robohash.org/hicnihilipsa.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (9, 'cvanderweedenburg7', 'Cristabel', 'Van Der Weedenburg', 'cvanderweedenburg7@wikimedia.orgx', '2019-11-02', 'https://robohash.org/quidemearumtenetur.png?size=150x150&set=set1', 1);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (10, 'ecornfoot8', 'Emmaline', 'Cornfoot', 'ecornfoot8@cargocollective.comx', '2020-02-17', 'https://robohash.org/blanditiismaioresest.png?size=150x150&set=set1', 2);
+insert into UserProfile (Id, DisplayName, FirstName, LastName, Email, CreateDateTime, ImageLocation, UserTypeId) values (11, 'jmaruska9', 'Jody', 'Maruska', 'jmaruska9@netscape.comx', '2020-02-09', 'https://robohash.org/voluptatemexercitationemdignissimos.png?size=150x150&set=set1', 1);
+set identity_insert [UserProfile] off
+
+set identity_insert [Post] on
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (1, 'morph front-end markets', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.', 'http://lorempixel.com/920/360/', '2019-08-01', '2019-12-04', 1, 3, 6);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (2, 'orchestrate value-added communities', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', 'http://lorempixel.com/920/360/', '2019-08-29', '2020-02-16', 1, 4, 4);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (3, 'engineer ubiquitous users', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.', 'http://lorempixel.com/920/360/', '2020-02-01', '2019-07-29', 0, 2, 9);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (4, 'deploy impactful architectures', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', 'http://lorempixel.com/920/360/', '2020-07-05', '2019-10-21', 0, 3, 1);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (5, 'empower 24/7 systems', 'Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.', 'http://lorempixel.com/920/360/', '2019-07-07', '2019-12-17', 0, 2, 6);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (6, 'benchmark web-enabled paradigms', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Proin risus. Praesent lectus.
+
+Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
+
+Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
+
+Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', 'http://lorempixel.com/920/360/', '2020-04-13', '2020-01-19', 0, 2, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (7, 'productize turn-key convergence', 'Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.', 'http://lorempixel.com/920/360/', '2019-08-25', '2020-06-25', 1, 1, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (8, 'drive front-end portals', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.', 'http://lorempixel.com/920/360/', '2020-03-04', '2020-04-14', 1, 4, 4);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (9, 'exploit e-business e-services', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', 'http://lorempixel.com/920/360/', '2019-09-20', '2019-07-23', 1, 4, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (10, 'incentivize virtual models', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.', 'http://lorempixel.com/920/360/', '2019-10-23', '2019-10-13', 1, 5, 9);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (11, 'syndicate cross-media paradigms', 'Curabitur at ipsum ac tellus semper interdum. Mauris ullamcorper purus sit amet nulla. Quisque arcu libero, rutrum ac, lobortis vel, dapibus at, diam.', 'http://lorempixel.com/920/360/', '2019-10-27', '2019-09-11', 0, 2, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (12, 'evolve sticky web-readiness', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.', 'http://lorempixel.com/920/360/', '2019-07-21', '2019-07-28', 1, 1, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (13, 'monetize mission-critical supply-chains', 'Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', 'http://lorempixel.com/920/360/', '2019-10-20', '2019-12-19', 0, 4, 6);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (14, 'synergize seamless supply-chains', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.', 'http://lorempixel.com/920/360/', '2019-09-23', '2020-01-17', 1, 4, 4);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (15, 'reintermediate transparent models', 'In congue. Etiam justo. Etiam pretium iaculis justo.
+
+In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', 'http://lorempixel.com/920/360/', '2020-03-17', '2020-01-18', 0, 1, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (16, 'grow frictionless e-tailers', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', 'http://lorempixel.com/920/360/', '2019-10-02', '2020-06-29', 1, 2, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (17, 'synthesize transparent niches', 'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.', 'http://lorempixel.com/920/360/', '2020-03-11', '2020-04-10', 1, 3, 5);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (18, 'streamline sticky e-commerce', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', 'http://lorempixel.com/920/360/', '2019-08-28', '2020-05-04', 1, 4, 10);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (19, 'architect next-generation e-business', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.
+
+Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.
+
+Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.
+
+Fusce consequat. Nulla nisl. Nunc nisl.
+
+Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', 'http://lorempixel.com/920/360/', '2020-02-08', '2020-03-21', 1, 5, 2);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (20, 'transition next-generation networks', 'Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.', 'http://lorempixel.com/920/360/', '2020-06-20', '2020-05-01', 1, 3, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (21, 'harness wireless synergies', 'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', 'http://lorempixel.com/920/360/', '2019-10-18', '2020-01-24', 0, 5, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (22, 'incubate collaborative e-commerce', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.
+
+Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.
+
+Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.
+
+Fusce consequat. Nulla nisl. Nunc nisl.', 'http://lorempixel.com/920/360/', '2020-05-28', '2019-10-24', 1, 4, 6);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (23, 'productize enterprise e-commerce', 'Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.
+
+Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.
+
+Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.
+
+Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', 'http://lorempixel.com/920/360/', '2020-01-28', '2020-05-18', 0, 1, 3);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (24, 'incubate mission-critical channels', 'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.
+
+In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet.
+
+Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.
+
+Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', 'http://lorempixel.com/920/360/', '2019-11-04', '2019-11-24', 1, 1, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (25, 'visualize enterprise e-markets', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', 'http://lorempixel.com/920/360/', '2019-10-29', '2020-02-07', 0, 3, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (26, 'productize enterprise solutions', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.
+
+Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.', 'http://lorempixel.com/920/360/', '2020-03-14', '2019-12-08', 0, 3, 10);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (27, 'visualize dynamic relationships', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', 'http://lorempixel.com/920/360/', '2019-11-15', '2019-09-23', 0, 1, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (28, 'engage next-generation e-tailers', 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.
+
+Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', 'http://lorempixel.com/920/360/', '2019-10-25', '2020-01-04', 0, 2, 1);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (29, 'integrate open-source applications', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Proin risus. Praesent lectus.
+
+Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
+
+Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.', 'http://lorempixel.com/920/360/', '2020-05-19', '2019-12-20', 0, 4, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (30, 'deploy magnetic metrics', 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.
+
+Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', 'http://lorempixel.com/920/360/', '2019-07-12', '2020-03-23', 1, 4, 5);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (31, 'engage dynamic deliverables', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.', 'http://lorempixel.com/920/360/', '2019-07-28', '2019-10-01', 0, 5, 5);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (32, 'target bleeding-edge architectures', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.
+
+Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.', 'http://lorempixel.com/920/360/', '2019-12-10', '2019-08-30', 1, 3, 5);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (33, 'innovate cross-platform supply-chains', 'Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.', 'http://lorempixel.com/920/360/', '2020-04-07', '2019-11-10', 1, 1, 10);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (34, 'innovate strategic convergence', 'Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.
+
+Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', 'http://lorempixel.com/920/360/', '2020-03-26', '2019-10-24', 1, 3, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (35, 'engage real-time vortals', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', 'http://lorempixel.com/920/360/', '2019-08-17', '2019-12-02', 0, 5, 9);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (36, 'productize transparent e-commerce', 'Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.
+
+Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.
+
+Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.', 'http://lorempixel.com/920/360/', '2020-03-04', '2019-08-07', 0, 5, 4);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (37, 'benchmark web-enabled markets', 'Fusce consequat. Nulla nisl. Nunc nisl.
+
+Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.
+
+In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', 'http://lorempixel.com/920/360/', '2019-09-07', '2020-05-03', 1, 5, 9);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (38, 'streamline dynamic initiatives', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.', 'http://lorempixel.com/920/360/', '2020-04-11', '2020-06-19', 0, 5, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (39, 'grow cross-media initiatives', 'Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.
+
+In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', 'http://lorempixel.com/920/360/', '2020-05-03', '2020-05-23', 0, 1, 9);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (40, 'morph turn-key e-commerce', 'Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.
+
+In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.
+
+Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.', 'http://lorempixel.com/920/360/', '2019-09-19', '2020-04-27', 1, 4, 6);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (41, 'monetize visionary platforms', 'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', 'http://lorempixel.com/920/360/', '2019-10-19', '2019-12-05', 1, 3, 7);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (42, 'expedite sexy deliverables', 'Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.
+
+In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.', 'http://lorempixel.com/920/360/', '2019-07-07', '2020-05-01', 0, 3, 8);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (43, 'streamline cross-platform web services', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.
+
+Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', 'http://lorempixel.com/920/360/', '2020-04-13', '2019-07-13', 1, 3, 9);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (44, 'deploy visionary technologies', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.
+
+Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', 'http://lorempixel.com/920/360/', '2019-09-23', '2019-12-19', 0, 4, 6);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (45, 'engage 24/365 ROI', 'Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.', 'http://lorempixel.com/920/360/', '2020-03-03', '2019-12-18', 0, 1, 1);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (46, 'harness distributed portals', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', 'http://lorempixel.com/920/360/', '2020-03-06', '2019-08-02', 0, 1, 3);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (47, 'visualize killer systems', 'Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.', 'http://lorempixel.com/920/360/', '2019-09-18', '2020-03-06', 1, 3, 5);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (48, 'scale best-of-breed technologies', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.
+
+Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.
+
+Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.', 'http://lorempixel.com/920/360/', '2019-11-05', '2019-09-29', 0, 1, 1);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (49, 'streamline virtual web-readiness', 'Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.
+
+Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', 'http://lorempixel.com/920/360/', '2020-02-18', '2020-03-12', 1, 2, 4);
+insert into Post (Id, Title, Content, ImageLocation, CreateDateTime, PublishDateTime, IsApproved, CategoryId, UserProfileId) values (50, 'reintermediate compelling interfaces', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.', 'http://lorempixel.com/920/360/', '2019-10-13', '2020-02-08', 0, 4, 5);
+set identity_insert [Post] off
+
+set identity_insert [Comment] on
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (1, 20, 4, 'Sed sagittis.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.', '2020-05-19');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (2, 11, 8, 'Pellentesque viverra pede ac diam.', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.', '2020-05-11');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (3, 15, 8, 'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est.', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2020-07-01');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (4, 5, 8, 'Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla.', 'Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', '2020-05-10');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (5, 23, 8, 'Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', 'Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.', '2020-05-27');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (6, 15, 7, 'Nulla tempus.', 'Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', '2020-06-02');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (7, 20, 5, 'Quisque id justo sit amet sapien dignissim vestibulum.', 'Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.', '2020-06-04');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (8, 22, 9, 'Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', 'Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.', '2020-05-28');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (9, 7, 6, 'Nulla justo.', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2020-05-04');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (10, 1, 1, 'Etiam pretium iaculis justo.', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', '2020-05-16');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (11, 14, 6, 'Nullam molestie nibh in lectus.', 'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.', '2020-06-13');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (12, 3, 9, 'Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', 'Fusce consequat. Nulla nisl. Nunc nisl.', '2020-06-23');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (13, 23, 9, 'Morbi porttitor lorem id ligula.', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', '2020-06-21');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (14, 22, 5, 'Nullam molestie nibh in lectus.', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2020-06-09');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (15, 12, 9, 'Phasellus sit amet erat.', 'Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.', '2020-06-21');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (16, 7, 10, 'Nulla ac enim.', 'Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.', '2020-07-02');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (17, 22, 10, 'Donec ut mauris eget massa tempor convallis.', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2020-06-21');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (18, 7, 4, 'Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante.', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2020-06-07');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (19, 17, 8, 'Nulla tempus.', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', '2020-05-04');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (20, 15, 7, 'Nulla mollis molestie lorem.', 'Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', '2020-06-03');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (21, 16, 3, 'Proin leo odio, porttitor id, consequat in, consequat ut, nulla.', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2020-06-14');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (22, 21, 4, 'Donec posuere metus vitae ipsum.', 'Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius.', '2020-05-17');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (23, 1, 3, 'Morbi vel lectus in quam fringilla rhoncus.', 'Fusce consequat. Nulla nisl. Nunc nisl.', '2020-06-06');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (24, 3, 6, 'Suspendisse potenti.', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2020-06-27');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (25, 22, 10, 'Curabitur convallis.', 'In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.', '2020-05-16');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (26, 13, 1, 'Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', 'In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet.', '2020-05-22');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (27, 1, 6, 'Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue.', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.', '2020-06-17');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (28, 24, 3, 'Donec ut mauris eget massa tempor convallis.', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2020-06-01');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (29, 11, 5, 'Praesent blandit.', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2020-05-05');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (30, 11, 7, 'Nam dui.', 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2020-06-10');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (31, 22, 8, 'Donec ut dolor.', 'Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.', '2020-06-29');
+insert into Comment (Id, PostId, UserProfileId, Subject, Content, CreateDateTime) values (32, 7, 10, 'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam.', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2020-06-15');
+set identity_insert [Comment] off

--- a/TabloidFullStack/TabloidFullStack/Controllers/PostController.cs
+++ b/TabloidFullStack/TabloidFullStack/Controllers/PostController.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using TabloidFullStack.Repositories;
+using TabloidFullStack.Models;
+using System.Security.Claims;
+
+namespace TabloidFullStack.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PostController : ControllerBase
+    {
+        private readonly IPostRepository _postRepository;
+
+        public PostController(IPostRepository postRepository)
+        {
+            _postRepository = postRepository;
+        }
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok(_postRepository.GetAllPosts());
+        }
+        [HttpGet("GetUsersPosts/{id}")]
+        public IActionResult Get(int id)
+        {
+            List<Post> posts = _postRepository.GetPostsByUserId(id);
+            if (posts == null)
+            {
+                return NotFound();
+            }
+            return Ok(posts);
+        }
+    }
+}

--- a/TabloidFullStack/TabloidFullStack/Models/Post.cs
+++ b/TabloidFullStack/TabloidFullStack/Models/Post.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace TabloidFullStack.Models
+{
+    public class Post
+    {
+        public int Id { get; set; }
+        [Required]
+        public string Title { get; set; }
+        [Required]
+        public string Content { get; set; }
+        [DisplayName("Image URL")]
+        public string ImageLocation { get; set; }
+        public DateTime CreateDateTime { get; set; }
+        [DisplayName("Published")]
+        public DateTime? PublishDateTime { get; set; }
+        public bool IsApproved { get; set; }
+        [Required]
+        [DisplayName("Category")]
+        public int CategoryId { get; set; }
+        public int UserProfileId { get; set; }
+        public UserProfile UserProfile { get; set; }
+    }
+}

--- a/TabloidFullStack/TabloidFullStack/Program.cs
+++ b/TabloidFullStack/TabloidFullStack/Program.cs
@@ -12,6 +12,7 @@ namespace TabloidFullStack
 
             builder.Services.AddControllers();
             builder.Services.AddTransient<IUserRepository, UserRepository>();
+            builder.Services.AddTransient<IPostRepository, PostRepository>();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/TabloidFullStack/TabloidFullStack/Repositories/IPostRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/IPostRepository.cs
@@ -1,0 +1,12 @@
+﻿using TabloidFullStack.Models;
+
+namespace TabloidFullStack.Repositories
+{
+    public interface IPostRepository
+    {
+        List<Post> GetAllPosts();
+        List<Post> GetPostsByUserId(int userProfileId);
+        Post GetPostById(int postId);
+
+    }
+}

--- a/TabloidFullStack/TabloidFullStack/Repositories/PostRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/PostRepository.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using TabloidFullStack.Models;
+using TabloidFullStack.Utils;
+
+namespace TabloidFullStack.Repositories
+{
+    public class PostRepository : BaseRepository, IPostRepository
+    {
+        public PostRepository(IConfiguration config) : base(config) { }
+
+        private Post NewPostFromReader(SqlDataReader reader)
+        {
+            return new Post()
+            {
+                Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                Title = reader.GetString(reader.GetOrdinal("Title")),
+                Content = reader.GetString(reader.GetOrdinal("Content")),
+                ImageLocation = DbUtils.GetNullableString(reader, "ImageUrl"),
+                CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                PublishDateTime = DbUtils.GetNullableDateTime(reader, "PublishDateTime"),
+                UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileId")),
+                UserProfile = new UserProfile()
+                {
+                    Id = reader.GetInt32(reader.GetOrdinal("UserProfileId")),
+                    FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                    LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                    DisplayName = reader.GetString(reader.GetOrdinal("DisplayName")),
+                    Email = reader.GetString(reader.GetOrdinal("Email")),
+                    CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                    ImageLocation = DbUtils.GetNullableString(reader, "UserImageUrl"),
+                    UserTypeId = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                    UserType = new UserType()
+                    {
+                        Id = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                        Name = reader.GetString(reader.GetOrdinal("UserTypeName"))
+                    }
+                }
+            };
+        }
+        public List<Post> GetAllPosts()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT p.Id, p.Title, p.Content, p.ImageLocation AS ImageUrl, p.CreateDateTime, p.PublishDateTime, p.IsApproved, p.CategoryId, p.UserProfileId,
+                            c.[Name] as CategoryName,
+                            u.FirstName, u.LastName, u.DisplayName, u.Email, u.CreateDateTime, u.ImageLocation as UserImageUrl, u.UserTypeId,
+                            ut.[Name] as UserTypeName
+                        FROM Post p
+                            LEFT JOIN Category c ON p.CategoryId = c.Id
+                            LEFT JOIN UserProfile u ON p.UserProfileId = u.Id
+                            LEFT JOIN UserType ut ON u.UserTypeId = ut.Id
+                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME()
+                        ORDER BY PublishDateTime desc
+                    ";
+                    var reader = cmd.ExecuteReader();
+
+                    var posts = new List<Post>();
+
+                    while (reader.Read())
+                    {
+                        posts.Add(NewPostFromReader(reader));
+                    }
+                    reader.Close();
+
+                    return posts;
+                }
+            }
+        }
+        public List<Post> GetPostsByUserId(int userProfileId)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT p.Id, p.Title, p.Content, p.ImageLocation AS ImageUrl, p.CreateDateTime, p.PublishDateTime, p.IsApproved, p.CategoryId, p.UserProfileId,
+                            c.[Name] as CategoryName,
+                            u.FirstName, u.LastName, u.DisplayName, u.Email, u.CreateDateTime, u.ImageLocation as UserImageUrl, u.UserTypeId,
+                            ut.[Name] as UserTypeName
+                        FROM Post p
+                            LEFT JOIN Category c ON p.CategoryId = c.Id
+                            LEFT JOIN UserProfile u ON p.UserProfileId = u.Id
+                            LEFT JOIN UserType ut ON u.UserTypeId = ut.Id
+                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME() AND p.UserProfileId = @userProfileId
+                        ORDER BY p.CreateDateTime desc
+                    ";
+                    cmd.Parameters.AddWithValue("@userProfileId", userProfileId);
+                    var reader = cmd.ExecuteReader();
+
+                    var posts = new List<Post>();
+
+                    while (reader.Read())
+                    {
+                        posts.Add(NewPostFromReader(reader));
+                    }
+                    reader.Close();
+
+                    return posts;
+                }
+            }
+        }
+
+        public Post GetPostById(int postId)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/TabloidFullStack/TabloidFullStack/Utils/DbUtils.cs
+++ b/TabloidFullStack/TabloidFullStack/Utils/DbUtils.cs
@@ -79,6 +79,15 @@ namespace TabloidFullStack.Utils
 
             return reader.GetDateTime(ordinal);
         }
+        public static string GetNullableString(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            if (reader.IsDBNull(ordinal))
+            {
+                return null;
+            }
+            return reader.GetString(ordinal);
+        }
 
         /// <summary>
         ///  Determine if the value a given column is NULL

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/package.json
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/package.json
@@ -2,6 +2,7 @@
   "name": "tabloid",
   "version": "0.1.0",
   "private": true,
+  "proxy": "https://localhost:5001",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/Managers/PostManager.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/Managers/PostManager.js
@@ -1,0 +1,16 @@
+// swagger url
+const baseUrl = '/api/Post';
+
+// Fetch all posts
+export const getAllPosts = () => {
+    return fetch(baseUrl)
+        .then((res) => res.json())
+};
+
+export const getPostsByUserId = (id) => {
+    return fetch(`${baseUrl}/GetUsersPosts/${id}`).then((res) => res.json())
+}
+
+export const getPostById = (id) => {
+    return fetch(`/api/post/${id}`).then((res) => res.json())
+}

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
@@ -1,12 +1,21 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
 import Hello from "./Hello";
+import Login from "./Login";
+import { PostDetails } from "./Posts/PostDetails";
+import { PostList } from "./Posts/PostList";
+import { UserPosts } from "./Posts/UserPosts";
+
 
 export default function ApplicationViews() {
 
  return(
       <Routes>
         <Route path="/" element={<Hello />} />
+        <Route path="/posts" element={<PostList />} />
+        <Route path="/posts/:id" element={<PostDetails />} />
+        <Route path="/myPosts" element={<UserPosts />} />
+        <Route path="/login" element={<Login />} />
       </Routes>
    );
  

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
@@ -2,10 +2,8 @@ import React from "react";
 import { Route, Routes } from "react-router-dom";
 import Hello from "./Hello";
 import TagList from "./tags/TagList";
-import Login from "./Login";
-import { PostDetails } from "./Posts/PostDetails";
 import { PostList } from "./Posts/PostList";
-import { UserPosts } from "./Posts/UserPosts";
+
 
 
 export default function ApplicationViews() {
@@ -13,6 +11,8 @@ export default function ApplicationViews() {
  return(
       <Routes>
         <Route path="/" element={<Hello />} />
+        <Route path="tags"element={<TagList />} />
+        <Route path="posts"element={<PostList />} />
       </Routes>
    );
  

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Header.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Header.js
@@ -26,6 +26,7 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
             {isLoggedIn &&
               <NavItem>
                 <NavLink tag={RRNavLink} to="/">Home</NavLink>
+                <NavLink tag={RRNavLink} to="/posts">Posts</NavLink>
               </NavItem>
             }
           </Nav>

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/Post.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/Post.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export const Post = ({ post }) => {
+  return (
+      <tbody>
+        <tr>
+          <td>{post.title}</td>
+          <td>{`${post.userProfile.firstName} ${post.userProfile.lastName}`}</td>
+          <td><Link to={`/posts/${post.id}`}>Details</Link></td>
+        </tr>
+      </tbody>
+  );
+};

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/PostDetails.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/PostDetails.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+import { Card, CardImg, CardBody, CardTitle, CardText } from "reactstrap";
+import { Link, useParams } from "react-router-dom";
+import { getPostById } from "../../Managers/PostManager";
+
+export const PostDetails = () => {
+  const [post, setPost] = useState();
+  const { id } = useParams();
+
+  useEffect(() => {
+    getPostById(id).then(setPost);
+  }, []);
+
+  if (!post) {
+    return null;
+  }
+
+  return (
+    <Card>
+        <CardTitle>Title: <b>{post.title}</b></CardTitle>
+        <CardImg top src={post.ImageLocation} alt="iMAgE Is bROkeN..." />
+        <CardBody>
+            <CardText>{post.content}</CardText>
+            <CardText>
+                Posted on {post.createDateTime} by <b>{post?.userProfile?.displayName}</b>
+            </CardText>
+        </CardBody>
+    </Card>
+  );
+};
+
+
+
+
+
+
+
+
+

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/PostList.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/PostList.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react"
+import { getAllPosts } from "../../Managers/PostManager";
+import { Post } from "./Post";
+import { Table } from "reactstrap";
+
+export const PostList = () => {
+    const [posts, setPosts] = useState([]);
+
+    const getPosts = () => {
+        getAllPosts().then(allPosts => setPosts(allPosts));
+    }
+
+    useEffect(() => {
+        getPosts();
+    }, [])
+
+    return (<>
+      <div className="post-list">
+        <div className="row justify-content-center">
+          <div className="cards-column">
+            <Table> 
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Author</th>
+                <th>Category</th>
+              </tr>
+            </thead>
+              {posts.map((post) => {
+                return  <Post key={post.id} post={post} />
+              })}
+            </Table>
+          </div>
+        </div>
+      </div>
+    
+    </>
+    )
+}
+
+
+
+ 

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/Posts.css
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/Posts.css
@@ -1,0 +1,6 @@
+.post-title {
+    text-transform: capitalize;
+}
+.post-card {
+    margin-bottom: 5px;
+}

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/UserPosts.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/Posts/UserPosts.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { getPostsByUserId } from "../../Managers/PostManager";
+import { Post } from "./Post";
+import { Table } from "reactstrap";
+
+export const UserPosts = () => {
+    const [userPosts, setUserPosts] = useState([])
+
+    const localTabloidUser = localStorage.getItem("userProfile");
+    const tabloidUserObject = JSON.parse(localTabloidUser)
+
+    useEffect(() => {
+        getPostsByUserId(tabloidUserObject.id)
+            .then((data) => {
+                setUserPosts(data)
+            })
+            .catch((error) => {
+                console.log("Error fetching your posts...", error)
+            })
+    }, [tabloidUserObject.id])
+
+    return (<>
+      <div className="post-list">
+        <div className="row justify-content-center">
+          <div className="cards-column">
+            <Table> 
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Author</th>
+                <th>Category</th>
+              </tr>
+            </thead>
+            {userPosts.map((post) => {
+              return  <Post key={post.id} post={post} />
+            })}
+            </Table>
+          </div>
+        </div>
+      </div>
+
+    </>)
+}


### PR DESCRIPTION
Description
User can now click "Posts" inside of the navbar to be guided to the "/posts" page to view all posts . [Ticket 03]

https://trello.com/c/aQOWVRgn

Type of change
 New feature (non-breaking change which adds functionality)

Testing Instructions
 Run git add and git commit whatever you're working on on your branch
 Run git checkout main
 Run git fetch --a
 Run git checkout HD-post-t03
 If you don't see the most recent version of my files, run git pull origin HD-post-t03
 Add all seed data by adding a new query and copying the code from the links below
 Use this to fill out tables and columns:
https://github.com/NewForce-Cohort-7/tabloidfullstack-hollywoodgoblins/blob/main/SQL/01_Tabloid_Create_DB.sql
 Use this to seed the database:
https://github.com/NewForce-Cohort-7/tabloidfullstack-hollywoodgoblins/blob/main/SQL/02_Tabloid_Seed_Data.sql
 To execute your query just press Ctrl+Shift+e inside of your query.
 Run the program by clicking the Green Arrow next to TabloidFullStack at the top.
 Navigate to TabloidFullStack/client/tabloid in your terminal
 Once there run command npm install and then npm start
 After running that command you should be brought to the sign in page. Use account [foo@bar.com](mailto:foo@bar.com) to login. (NOTE: There is no password.)
 You should now be brought to the home screen landing page that lists (Home, Posts, Logout), Click on "Posts".
You should now see all posts.
Checklist:
X My code follows the style guidelines of this project
X I have performed a self-review of my own code
X I have commented my code, particularly in hard-to-understand areas
X My changes generate no new warnings or errors
X I have added test instructions that prove my fix is effective or that my feature works